### PR TITLE
Use local timezone for change count default date

### DIFF
--- a/count/index.html
+++ b/count/index.html
@@ -214,7 +214,15 @@
 
       const datePicker = document.getElementById('date-picker');
       const lastEditedEl = document.getElementById('last-edited');
-      const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+      function formatLocalYmd(date = new Date()) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+      }
+
+      const today = formatLocalYmd();
       datePicker.value = today;
       let dateKey = datePicker.value || today;
 


### PR DESCRIPTION
## Summary
- compute the default change-count date using the client’s local timezone instead of UTC
- keep the date picker and date key in sync with the locally formatted YYYY-MM-DD string

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad918ba70832eb1becb606fc7758e)