### PR TITLE
Allow glow and wiggle to run together

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,9 @@
       animation: wiggle 2s ease-in-out infinite;
       transform-origin: center center;
     }
+    .sticker.glow.wiggle {
+      animation: glowPulse 2.2s ease-in-out infinite, wiggle 2s ease-in-out infinite;
+    }
     @keyframes wiggle {
       0%   { transform: rotate(0deg); }
       20%  { transform: rotate(1.2deg); }


### PR DESCRIPTION
## Summary
- allow the glow and wiggle sticker effects to run simultaneously by combining their animations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949cdd48640832eb720e32ce6596590)